### PR TITLE
Add const methods to IP and TCP to calculate correct checksum

### DIFF
--- a/include/tins/ip.h
+++ b/include/tins/ip.h
@@ -380,6 +380,17 @@ public:
     }
 
     /**
+     * \brief Calculate the correct checksum value.
+     *
+     * This will calculate and return the correct checksum value across all
+     * of the IP header fields. This is value that should be in the checksum
+     * field, but may not be.
+     *
+     * \return The calculated checksum for this IP PDU.
+     */
+    uint16_t calculate_checksum() const;
+    
+    /**
      * \brief Getter for the source address field.
      *
      * \return The source address for this IP PDU.
@@ -758,7 +769,11 @@ private:
     uint32_t pad_options_size(uint32_t size) const;
     void init_ip_fields();
     void write_serialization(uint8_t* buffer, uint32_t total_sz);
-    void write_option(const option& opt, Memory::OutputMemoryStream& stream);
+    uint16_t calculate_checksum(const uint8_t* buffer,
+                                const uint32_t total_sz,
+                                const uint16_t old_checksum) const;
+    void write_option(const option& opt, Memory::OutputMemoryStream& stream) const;
+    void stream_options(Memory::OutputMemoryStream &stream, const uint32_t pad_size) const;
     void add_route_option(option_identifier id, const generic_route_option_type& data);
     generic_route_option_type search_route_option(option_identifier id) const;
     void checksum(uint16_t new_check);

--- a/include/tins/tcp.h
+++ b/include/tins/tcp.h
@@ -226,6 +226,13 @@ public:
     }
 
     /**
+     * \brief Getter for the checksum field.
+     *
+     * \return The checksum field value.
+     */
+    uint16_t calculate_checksum() const;
+
+    /**
      * \brief Getter for the urgent pointer field.
      *
      * \return The urgent pointer field value.
@@ -606,6 +613,9 @@ private:
         return opt->to<T>();
     }
     
+    uint16_t calculate_checksum(const uint8_t *buffer,
+                                const uint32_t total_sz,
+                                const uint16_t old_checksum) const;
     void write_serialization(uint8_t* buffer, uint32_t total_sz);
     void checksum(uint16_t new_check);
     uint32_t calculate_options_size() const;
@@ -613,7 +623,8 @@ private:
     options_type::const_iterator search_option_iterator(OptionTypes type) const;
     options_type::iterator search_option_iterator(OptionTypes type);
     
-    void write_option(const option& opt, Memory::OutputMemoryStream& stream);
+    void write_option(const option& opt, Memory::OutputMemoryStream& stream) const;
+    void stream_options(Memory::OutputMemoryStream &stream, const uint32_t pad_size) const;
 
     options_type options_;
     tcp_header header_;

--- a/include/tins/utils/checksum_utils.h
+++ b/include/tins/utils/checksum_utils.h
@@ -64,6 +64,17 @@ TINS_API uint32_t do_checksum(const uint8_t* start, const uint8_t* end);
  */
 TINS_API uint16_t sum_range(const uint8_t* start, const uint8_t* end);
 
+/** 
+ * \brief Fold 32 bit sum to produce 16 bit sum.
+ *
+ * This implements the algorithm used by the TCP/IP standard checksum to add
+ * overflow bits back into the lower 16 bit word.
+ * \param sum 32-bit sum
+ * \return 16-bit folded sum
+ * in network endian
+ */
+TINS_API uint16_t fold_sum(uint32_t sum);
+
 /**
  * \brief Performs the pseudo header checksum used in TCP and UDP PDUs.
  *

--- a/src/utils/checksum_utils.cpp
+++ b/src/utils/checksum_utils.cpp
@@ -65,10 +65,16 @@ uint16_t sum_range(const uint8_t* start, const uint8_t* end) {
     }
 
     checksum += padding;
-    while (checksum >> 16) {
-        checksum = (checksum & 0xffff) + (checksum >> 16);
+    
+    return fold_sum(checksum);
+}
+
+uint16_t fold_sum(uint32_t sum) {
+    while (sum >> 16) {
+        sum = (sum & 0xffff) + (sum >> 16);
     }
-    return checksum;  
+    
+    return static_cast<uint16_t>(sum);
 }
 
 template <size_t buffer_size, typename AddressType>


### PR DESCRIPTION
The checksum was only calculated in the write_serialization methods, but
other header fields were updated such as header length and protocol. The
new calculate_checksum methods are const, so they do not modify any
fields in the header. They are useful for checking if the checksum in
a received packet is valid or not.