### PR TITLE
Add option not to throw malformed_packet exception

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,15 @@ IF(LIBTINS_ENABLE_PCAP)
     SET(TINS_HAVE_PCAP ON)
 ENDIF()
 
+# By default, a malformed_packet exception is thrown when certain errors occur
+# while constructing a packet. This can be turned off, so that the packet will
+# be constructed as much as possible but a malformed flag will be set.
+OPTION(LIBTINS_THROW_MALFORMED_PACKET "Enable throwing malformed_packet exception" ON)
+
+IF(LIBTINS_THROW_MALFORMED_PACKET)
+    SET(TINS_THROW_MALFORMED_PACKET ON)
+ENDIF()
+
 # Set some Windows specific flags
 IF(WIN32)
     # We need to link against these libs

--- a/include/tins/config.h.in
+++ b/include/tins/config.h.in
@@ -31,6 +31,9 @@
 /* Have libpcap */
 #cmakedefine TINS_HAVE_PCAP
 
+/* Throw malformed_packet */
+#cmakedefine TINS_THROW_MALFORMED_PACKET
+
 /* Version macros */
 #define TINS_VERSION_MAJOR ${TINS_VERSION_MAJOR}
 #define TINS_VERSION_MINOR ${TINS_VERSION_MINOR}

--- a/include/tins/exceptions.h
+++ b/include/tins/exceptions.h
@@ -67,6 +67,14 @@ public:
 };
 
 /**
+ * \brief Exception thrown when insufficient 
+ */
+class insufficient_data : public exception_base {
+public:
+    insufficient_data() : exception_base("Insufficient data in stream") { }
+};
+
+/**
  * \brief Exception thrown when serializing a packet fails.
  */
 class serialization_error : public exception_base {

--- a/include/tins/memory_helpers.h
+++ b/include/tins/memory_helpers.h
@@ -95,7 +95,7 @@ public:
     template <typename T>
     void read(T& value) {
         if (!can_read(sizeof(value))) {
-            throw malformed_packet();
+            throw insufficient_data();
         }
         read_value(buffer_, value);
         skip(sizeof(value));
@@ -103,7 +103,7 @@ public:
 
     void skip(size_t size) {
         if (TINS_UNLIKELY(size > size_)) {
-            throw malformed_packet();
+            throw insufficient_data();
         }
         buffer_ += size;
         size_ -= size;
@@ -115,7 +115,7 @@ public:
 
     void read(void* output_buffer, size_t output_buffer_size) {
         if (!can_read(output_buffer_size)) {
-            throw malformed_packet();
+            throw insufficient_data();
         }
         read_data(buffer_, (uint8_t*)output_buffer, output_buffer_size);
         skip(output_buffer_size);
@@ -191,7 +191,7 @@ public:
 
     void skip(size_t size) {
         if (TINS_UNLIKELY(size > size_)) {
-            throw malformed_packet();
+            throw insufficient_data();
         }
         buffer_ += size;
         size_ -= size;

--- a/include/tins/pdu.h
+++ b/include/tins/pdu.h
@@ -297,6 +297,14 @@ public:
     }
     
     /**
+     * Getter for malformed flag
+     * \return True if the current PDU header is malformed.
+     */
+    bool is_malformed() const {
+        return malformed_;
+    }
+    
+    /**
      * \brief Releases the inner PDU.
      * 
      * This method makes this PDU to <b>no longer own</b> the inner
@@ -341,7 +349,7 @@ public:
      */
     serialization_type serialize();
 
-    /**
+    /** 
      * \brief Finds and returns the first PDU that matches the given flag.
      *
      * This method searches for the first PDU which has the same type flag as
@@ -486,6 +494,39 @@ protected:
     void copy_inner_pdu(const PDU& pdu);
 
     /**
+     * \brief Setter for malformed flag.
+     *
+     * \param new_malformed The new malformed flag.
+     */
+    void malformed(bool new_malformed) {
+        malformed_ = new_malformed;
+        
+#ifdef TINS_THROW_MALFORMED_PACKET
+        if (malformed_) {
+            throw malformed_packet();
+        }
+#endif
+    }
+    
+    /**
+     * \brief Setter for malformed flag for use in const methods.
+     *
+     * This will not cause the malformed flag to be updated, but it will
+     * throw an exception if the library has been configured that way.
+     *
+     * \param new_malformed If true, then throw exception if configured.
+     */
+    void malformed(bool new_malformed) const {
+#ifdef TINS_THROW_MALFORMED_PACKET
+        if (new_malformed) {
+            throw malformed_packet();
+        }
+#else
+        (void)new_malformed;
+#endif
+    }
+    
+    /**
      * \brief Prepares this PDU for serialization.
      * 
      * This method is called before the inner PDUs are serialized.
@@ -520,6 +561,7 @@ private:
 
     PDU* inner_pdu_;
     PDU* parent_pdu_;
+    bool malformed_;
 };
 
 /**

--- a/src/bootp.cpp
+++ b/src/bootp.cpp
@@ -47,9 +47,17 @@ BootP::BootP()
 BootP::BootP(const uint8_t* buffer, uint32_t total_sz, uint32_t vend_field_size) 
 : vend_(vend_field_size) {
     InputMemoryStream stream(buffer, total_sz);
-    stream.read(bootp_);
+    try {
+        stream.read(bootp_);
+    }
+    catch (const insufficient_data &) {
+        malformed(true);
+        return;
+    }
+    
     if (!stream.can_read(vend_field_size)) {
-        throw malformed_packet();
+        malformed(true);
+        return;
     }
     stream.read(vend_, vend_field_size);
 }

--- a/src/detail/pdu_helpers.cpp
+++ b/src/detail/pdu_helpers.cpp
@@ -60,40 +60,35 @@ Tins::PDU* pdu_from_flag(Constants::Ethernet::e flag,
                          const uint8_t* buffer,
                          uint32_t size,
                          bool rawpdu_on_no_match) {
-    try {
-        switch (flag) {
-            case Tins::Constants::Ethernet::IP:
-                return new IP(buffer, size);
-            case Constants::Ethernet::IPV6:
-                return new IPv6(buffer, size);
-            case Tins::Constants::Ethernet::ARP:
-                return new ARP(buffer, size);
-            case Tins::Constants::Ethernet::PPPOED:
-            case Tins::Constants::Ethernet::PPPOES:
-                return new PPPoE(buffer, size);
-            case Tins::Constants::Ethernet::EAPOL:
-                return EAPOL::from_bytes(buffer, size);
-            case Tins::Constants::Ethernet::VLAN:
-            case Tins::Constants::Ethernet::QINQ:
-            case Tins::Constants::Ethernet::OLD_QINQ:
-                return new Dot1Q(buffer, size);
-            case Tins::Constants::Ethernet::MPLS:
-                return new MPLS(buffer, size);
-            default:
-                {
-                    PDU* pdu = Internals::allocate<EthernetII>(
-                        static_cast<uint16_t>(flag),
-                        buffer,
-                        size
-                        );
-                    if (pdu) {
-                        return pdu;
-                    }
-                }
+    switch (flag) {
+        case Constants::Ethernet::IP:
+            return new IP(buffer, size);
+        case Constants::Ethernet::IPV6:
+            return new IPv6(buffer, size);
+        case Constants::Ethernet::ARP:
+            return new ARP(buffer, size);
+        case Constants::Ethernet::PPPOED:
+        case Constants::Ethernet::PPPOES:
+            return new PPPoE(buffer, size);
+        case Constants::Ethernet::EAPOL:
+            return EAPOL::from_bytes(buffer, size);
+        case Constants::Ethernet::VLAN:
+        case Constants::Ethernet::QINQ:
+        case Constants::Ethernet::OLD_QINQ:
+            return new Dot1Q(buffer, size);
+        case Constants::Ethernet::MPLS:
+            return new MPLS(buffer, size);
+        default:
+        {
+            PDU* pdu = Internals::allocate<EthernetII>(
+                static_cast<uint16_t>(flag),
+                buffer,
+                size
+                );
+            if (pdu) {
+                return pdu;
+            }
         }
-    }
-    catch (const malformed_packet &e) {
-        /* Continue to return statement below. */
     }
 
     return rawpdu_on_no_match ? new RawPDU(buffer, size) : 0;
@@ -123,10 +118,8 @@ Tins::PDU* pdu_from_flag(Constants::IP::e flag,
         default:
             break;
     }
-    if (rawpdu_on_no_match) {
-        return new Tins::RawPDU(buffer, size);
-    }
-    return 0;
+    
+    return rawpdu_on_no_match ? new Tins::RawPDU(buffer, size) : 0;
 }
 
 #ifdef TINS_HAVE_PCAP
@@ -175,36 +168,38 @@ Tins::PDU* pdu_from_flag(PDU::PDUType type, const uint8_t* buffer, uint32_t size
             return new Tins::IEEE802_3(buffer, size);
         case Tins::PDU::PPPOE:
             return new Tins::PPPoE(buffer, size);
-        #ifdef TINS_HAVE_DOT11
-            case Tins::PDU::RADIOTAP:
-                return new Tins::RadioTap(buffer, size);
-            case Tins::PDU::DOT11:
-            case Tins::PDU::DOT11_ACK:
-            case Tins::PDU::DOT11_ASSOC_REQ:
-            case Tins::PDU::DOT11_ASSOC_RESP:
-            case Tins::PDU::DOT11_AUTH:
-            case Tins::PDU::DOT11_BEACON:
-            case Tins::PDU::DOT11_BLOCK_ACK:
-            case Tins::PDU::DOT11_BLOCK_ACK_REQ:
-            case Tins::PDU::DOT11_CF_END:
-            case Tins::PDU::DOT11_DATA:
-            case Tins::PDU::DOT11_CONTROL:
-            case Tins::PDU::DOT11_DEAUTH:
-            case Tins::PDU::DOT11_DIASSOC:
-            case Tins::PDU::DOT11_END_CF_ACK:
-            case Tins::PDU::DOT11_MANAGEMENT:
-            case Tins::PDU::DOT11_PROBE_REQ:
-            case Tins::PDU::DOT11_PROBE_RESP:
-            case Tins::PDU::DOT11_PS_POLL:
-            case Tins::PDU::DOT11_REASSOC_REQ:
-            case Tins::PDU::DOT11_REASSOC_RESP:
-            case Tins::PDU::DOT11_RTS:
-            case Tins::PDU::DOT11_QOS_DATA:
-                return Tins::Dot11::from_bytes(buffer, size);
-        #endif // TINS_HAVE_DOT11
+#ifdef TINS_HAVE_DOT11
+        case Tins::PDU::RADIOTAP:
+            return new Tins::RadioTap(buffer, size);
+        case Tins::PDU::DOT11:
+        case Tins::PDU::DOT11_ACK:
+        case Tins::PDU::DOT11_ASSOC_REQ:
+        case Tins::PDU::DOT11_ASSOC_RESP:
+        case Tins::PDU::DOT11_AUTH:
+        case Tins::PDU::DOT11_BEACON:
+        case Tins::PDU::DOT11_BLOCK_ACK:
+        case Tins::PDU::DOT11_BLOCK_ACK_REQ:
+        case Tins::PDU::DOT11_CF_END:
+        case Tins::PDU::DOT11_DATA:
+        case Tins::PDU::DOT11_CONTROL:
+        case Tins::PDU::DOT11_DEAUTH:
+        case Tins::PDU::DOT11_DIASSOC:
+        case Tins::PDU::DOT11_END_CF_ACK:
+        case Tins::PDU::DOT11_MANAGEMENT:
+        case Tins::PDU::DOT11_PROBE_REQ:
+        case Tins::PDU::DOT11_PROBE_RESP:
+        case Tins::PDU::DOT11_PS_POLL:
+        case Tins::PDU::DOT11_REASSOC_REQ:
+        case Tins::PDU::DOT11_REASSOC_RESP:
+        case Tins::PDU::DOT11_RTS:
+        case Tins::PDU::DOT11_QOS_DATA:
+            return Tins::Dot11::from_bytes(buffer, size);
+#endif // TINS_HAVE_DOT11
         default:
             return 0;
     };
+    
+    return 0;
 }
 
 Constants::Ethernet::e pdu_flag_to_ether_type(PDU::PDUType flag) {

--- a/src/dhcp.cpp
+++ b/src/dhcp.cpp
@@ -63,7 +63,8 @@ DHCP::DHCP(const uint8_t* buffer, uint32_t total_sz)
     stream.skip(BootP::header_size() - vend().size());
     const uint32_t magic_number = stream.read<uint32_t>();
     if (magic_number != Endian::host_to_be<uint32_t>(0x63825363)) {
-        throw malformed_packet();
+        malformed(true);
+        return;
     }
     // While there's data left
     while (stream) {
@@ -76,7 +77,8 @@ DHCP::DHCP(const uint8_t* buffer, uint32_t total_sz)
         }
         // Make sure we can read the payload size
         if (!stream.can_read(option_length)) {
-            throw malformed_packet();
+            malformed(true);
+            return;
         }
         add_option(option(option_type, option_length, stream.pointer()));
         stream.skip(option_length);

--- a/src/dhcpv6.cpp
+++ b/src/dhcpv6.cpp
@@ -106,7 +106,8 @@ DHCPv6::DHCPv6(const uint8_t* buffer, uint32_t total_sz)
 : options_size_() {
     InputMemoryStream stream(buffer, total_sz);
     if (!stream) {
-        throw malformed_packet();
+        malformed(true);
+        return;
     }
     // Relay Agent/Server Messages
     const MessageType message_type = (MessageType)*stream.pointer();
@@ -121,7 +122,8 @@ DHCPv6::DHCPv6(const uint8_t* buffer, uint32_t total_sz)
         uint16_t opt = stream.read_be<uint16_t>();
         uint16_t data_size = stream.read_be<uint16_t>();
         if (!stream.can_read(data_size)) {
-            throw malformed_packet();
+            malformed(true);
+            return;
         }
         add_option(option(opt, stream.pointer(), stream.pointer() + data_size));
         stream.skip(data_size);

--- a/src/ethernetII.cpp
+++ b/src/ethernetII.cpp
@@ -73,7 +73,13 @@ EthernetII::EthernetII(const address_type& dst_hw_addr,
 
 EthernetII::EthernetII(const uint8_t* buffer, uint32_t total_sz) {
     InputMemoryStream stream(buffer, total_sz);
-    stream.read(header_);
+    try {
+        stream.read(header_);
+    }
+    catch (const insufficient_data &) {
+        malformed(true);
+        return;
+    }
     // If there's any size left
     if (stream) {
         inner_pdu(

--- a/src/icmp.cpp
+++ b/src/icmp.cpp
@@ -61,7 +61,13 @@ ICMP::ICMP(Flags flag)
 ICMP::ICMP(const uint8_t* buffer, uint32_t total_sz) 
 : orig_timestamp_or_address_mask_(), recv_timestamp_(), trans_timestamp_() {
     InputMemoryStream stream(buffer, total_sz);
-    stream.read(header_);
+    try {
+        stream.read(header_);
+    }
+    catch (const insufficient_data &) {
+        malformed(true);
+        return;
+    }
     if (type() == TIMESTAMP_REQUEST || type() == TIMESTAMP_REPLY) {
         original_timestamp(stream.read<uint32_t>());
         receive_timestamp(stream.read<uint32_t>());

--- a/src/llc.cpp
+++ b/src/llc.cpp
@@ -60,7 +60,8 @@ LLC::LLC(const uint8_t* buffer, uint32_t total_sz) {
     InputMemoryStream stream(buffer, total_sz);
     stream.read(header_);
     if (!stream) {
-        throw malformed_packet();
+        malformed(true);
+        return;
     }
 	information_field_length_ = 0;
 	if ((*stream.pointer() & 0x03) == LLC::UNNUMBERED) {

--- a/src/memory_helpers.cpp
+++ b/src/memory_helpers.cpp
@@ -41,7 +41,7 @@ namespace Memory {
 
 void InputMemoryStream::read(vector<uint8_t>& value, size_t count) {
     if (!can_read(count)) {
-        throw malformed_packet();
+        throw insufficient_data();
     }
     value.assign(pointer(), pointer() + count);
     skip(count);
@@ -49,7 +49,7 @@ void InputMemoryStream::read(vector<uint8_t>& value, size_t count) {
 
 void InputMemoryStream::read(HWAddress<6>& address) {
     if (!can_read(address.size())) {
-        throw malformed_packet();
+        throw insufficient_data();
     }
     address = pointer();
     skip(address.size());
@@ -61,7 +61,7 @@ void InputMemoryStream::read(IPv4Address& address) {
 
 void InputMemoryStream::read(IPv6Address& address) {
     if (!can_read(IPv6Address::address_size)) {
-        throw malformed_packet();
+        throw insufficient_data();
     }
     address = pointer();
     skip(IPv6Address::address_size);

--- a/src/pdu.cpp
+++ b/src/pdu.cpp
@@ -48,17 +48,17 @@ PDU::metadata::metadata(uint32_t header_size, PDUType current_type, PDUType next
 // PDU
 
 PDU::PDU()
-: inner_pdu_(), parent_pdu_() {
-
+: inner_pdu_(), parent_pdu_(), malformed_() {
 }
 
 PDU::PDU(const PDU& other) 
-: inner_pdu_(), parent_pdu_() {
+: inner_pdu_(), parent_pdu_(), malformed_(other.malformed_) {
     copy_inner_pdu(other);
 }
 
 PDU& PDU::operator=(const PDU& other) {
     copy_inner_pdu(other);
+    malformed_ = other.malformed_;
     return* this;
 }
 

--- a/src/pktap.cpp
+++ b/src/pktap.cpp
@@ -46,7 +46,8 @@ PKTAP::PKTAP(const uint8_t* buffer, uint32_t total_sz) {
     stream.read(header_);
     uint32_t header_length = header_.length;
     if (header_length > total_sz || header_length < sizeof(header_)) {
-        throw malformed_packet();
+        malformed(true);
+        return;
     }
     stream.skip(header_length - sizeof(header_));
     if (header_.next && stream) {

--- a/src/pppoe.cpp
+++ b/src/pppoe.cpp
@@ -69,7 +69,8 @@ PPPoE::PPPoE(const uint8_t* buffer, uint32_t total_sz)
             TagTypes opt_type = static_cast<TagTypes>(stream.read<uint16_t>());
             uint16_t opt_len = stream.read_be<uint16_t>();
             if (!stream.can_read(opt_len)) {
-                throw malformed_packet();
+                malformed(true);
+                return;
             }
             add_tag(tag(opt_type, opt_len, stream.pointer()));
             stream.skip(opt_len);

--- a/src/radiotap.cpp
+++ b/src/radiotap.cpp
@@ -84,12 +84,14 @@ RadioTap::RadioTap(const uint8_t* buffer, uint32_t total_sz) {
     input.read(header_);
     uint32_t radiotap_size = length();
     if (TINS_UNLIKELY(radiotap_size < sizeof(header_) + sizeof(uint32_t))) {
-        throw malformed_packet();
+        malformed(true);
+        return;
     }
 
     radiotap_size -= sizeof(header_);
     if (TINS_UNLIKELY(radiotap_size + sizeof(uint32_t) > input.size())) {
-        throw malformed_packet();
+        malformed(true);
+        return;
     }
 
     options_payload_.assign(input.pointer(), input.pointer() + radiotap_size);
@@ -101,11 +103,13 @@ RadioTap::RadioTap(const uint8_t* buffer, uint32_t total_sz) {
         const uint8_t flags_value = *parser.current_option_ptr();
         if ((flags_value & FCS) != 0) {
             if (TINS_UNLIKELY(total_sz < sizeof(uint32_t))) {
-                throw malformed_packet();
+                malformed(true);
+                return;
             }
             total_sz -= sizeof(uint32_t);
             if (TINS_UNLIKELY((flags_value & FAILED_FCS) != 0)) {
-                throw malformed_packet();
+                malformed(true);
+                return;
             }
         }
     }

--- a/src/rsn_information.cpp
+++ b/src/rsn_information.cpp
@@ -61,14 +61,16 @@ void RSNInformation::init(const uint8_t* buffer, uint32_t total_sz) {
     group_suite((RSNInformation::CypherSuites)stream.read_le<uint32_t>());
     int pairwise_cyphers_size = stream.read_le<uint16_t>();
     if (!stream.can_read(pairwise_cyphers_size)) {
-        throw malformed_packet();
+        malformed(true);
+        return;
     }
     while (pairwise_cyphers_size--) {
         add_pairwise_cypher((RSNInformation::CypherSuites)stream.read_le<uint32_t>());
     }
     int akm_cyphers_size = stream.read_le<uint16_t>();
     if (!stream.can_read(akm_cyphers_size)) {
-        throw malformed_packet();
+        malformed(true);
+        return;
     }
     while (akm_cyphers_size--) {
         add_akm_cypher((RSNInformation::AKMSuites)stream.read_le<uint32_t>());

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -57,7 +57,13 @@ UDP::UDP(uint16_t dport, uint16_t sport)
 
 UDP::UDP(const uint8_t* buffer, uint32_t total_sz)  {
     InputMemoryStream stream(buffer, total_sz);
-    stream.read(header_);
+    try {
+        stream.read(header_);
+    }
+    catch (const insufficient_data &) {
+        malformed(true);
+        return;
+    }
     if (stream) {
         inner_pdu(new RawPDU(stream.pointer(), stream.size()));
     }


### PR DESCRIPTION
By default, a malformed_packet exception is thrown when certain errors occur
while constructing a packet. When this occurs during construction, the entire
stack of PDUs is ripped up. Now, this can be turned off, so that the packet will
be constructed as much as possible but a malformed flag will be set. The
partially constructed PDUs will be returned to the caller.

issue: upstream #269