### PR TITLE
Support IP/UDP checksum overriding for RoCEv2 and its icrc calculation

### DIFF
--- a/include/tins/ip.h
+++ b/include/tins/ip.h
@@ -380,12 +380,6 @@ public:
     }
 
     /**
-     * \brief Setter for the checksum field. Disables calculation
-     * during write serialization
-     */
-    void checksum(uint16_t new_check);
-
-    /**
      * \brief Calculate the correct checksum value.
      *
      * This will calculate and return the correct checksum value across all
@@ -499,6 +493,12 @@ public:
      * \param new_protocol The new protocol.
      */
     void protocol(uint8_t new_protocol);
+
+    /**
+     * \brief Setter for the checksum field. Disables calculation
+     * during write serialization
+     */
+    void checksum(uint16_t new_check);
 
     /**
      * \brief Setter for the source address field.

--- a/include/tins/ip.h
+++ b/include/tins/ip.h
@@ -787,7 +787,7 @@ private:
 
     options_type options_;
     ip_header header_;
-    bool auto_set_checksum;
+    bool auto_set_checksum_;
 };
 
 } // Tins

--- a/include/tins/ip.h
+++ b/include/tins/ip.h
@@ -380,6 +380,12 @@ public:
     }
 
     /**
+     * \brief Setter for the checksum field. Disables calculation
+     * during write serialization
+     */
+    void checksum(uint16_t new_check);
+
+    /**
      * \brief Calculate the correct checksum value.
      *
      * This will calculate and return the correct checksum value across all
@@ -776,12 +782,12 @@ private:
     void stream_options(Memory::OutputMemoryStream &stream, const uint32_t pad_size) const;
     void add_route_option(option_identifier id, const generic_route_option_type& data);
     generic_route_option_type search_route_option(option_identifier id) const;
-    void checksum(uint16_t new_check);
     options_type::const_iterator search_option_iterator(option_identifier id) const;
     options_type::iterator search_option_iterator(option_identifier id);
 
     options_type options_;
     ip_header header_;
+    bool auto_set_checksum;
 };
 
 } // Tins

--- a/include/tins/udp.h
+++ b/include/tins/udp.h
@@ -151,6 +151,11 @@ public:
     void length(uint16_t new_len);
 
     /**
+     * \brief Set whether checksum is used or not
+     * \param checksum true if used, false if not (transmited as 0)
+     */
+    void use_checksum(bool new_use_checksum);
+    /**
      * \brief Check whether ptr points to a valid response for this PDU.
      *
      * This compares the source and destination ports in the provided
@@ -194,6 +199,7 @@ private:
     void write_serialization(uint8_t* buffer, uint32_t total_sz);
 
     udp_header header_;
+    bool use_checksum_;
 };
 
 } // Tins

--- a/include/tins/udp.h
+++ b/include/tins/udp.h
@@ -151,10 +151,11 @@ public:
     void length(uint16_t new_len);
 
     /**
-     * \brief Set whether checksum is used or not
-     * \param checksum true if used, false if not (transmited as 0)
+     * \brief Set checksum value and disable automatic calculation 
+     * of checksum during write serialization.
+     * \param checksum The new checksum value
      */
-    void use_checksum(bool new_use_checksum);
+    void checksum(uint16_t new_checksum);
     /**
      * \brief Check whether ptr points to a valid response for this PDU.
      *
@@ -199,7 +200,7 @@ private:
     void write_serialization(uint8_t* buffer, uint32_t total_sz);
 
     udp_header header_;
-    bool use_checksum_;
+    bool auto_set_checksum;
 };
 
 } // Tins

--- a/include/tins/udp.h
+++ b/include/tins/udp.h
@@ -156,6 +156,7 @@ public:
      * \param checksum The new checksum value
      */
     void checksum(uint16_t new_checksum);
+
     /**
      * \brief Check whether ptr points to a valid response for this PDU.
      *
@@ -200,7 +201,7 @@ private:
     void write_serialization(uint8_t* buffer, uint32_t total_sz);
 
     udp_header header_;
-    bool auto_set_checksum;
+    bool auto_set_checksum_;
 };
 
 } // Tins

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -67,15 +67,15 @@ PDU::metadata IP::extract_metadata(const uint8_t *buffer, uint32_t total_sz) {
     return metadata(header->ihl * 4, pdu_flag, next_type);
 }
 
-IP::IP(address_type ip_dst, address_type ip_src) {
+IP::IP(address_type ip_dst, address_type ip_src) : 
+        auto_set_checksum_(true) {
     init_ip_fields();
     this->dst_addr(ip_dst);
     this->src_addr(ip_src); 
-    this->auto_set_checksum = true;
 }
 
-IP::IP(const uint8_t* buffer, uint32_t total_sz) {
-    this->auto_set_checksum = true;
+IP::IP(const uint8_t* buffer, uint32_t total_sz) :
+        auto_set_checksum_(true) {
     PduInputMemoryStream stream(this, buffer, total_sz);
     stream.read(header_);
 
@@ -217,7 +217,7 @@ void IP::protocol(uint8_t new_protocol) {
 
 void IP::checksum(uint16_t new_check) {
     header_.check = Endian::host_to_be(new_check);
-    auto_set_checksum = false;
+    auto_set_checksum_ = false;
 }
 
 uint16_t IP::calculate_checksum() const {
@@ -488,7 +488,7 @@ void IP::write_serialization(uint8_t* buffer, uint32_t total_sz) {
     stream_options(stream, (padded_options_size - options_size));
 
     // Calculate the checksum
-    if (auto_set_checksum) {
+    if (auto_set_checksum_) {
         header_.check = Endian::host_to_be(
             calculate_checksum(buffer, (stream.pointer() - buffer), header_.check));
     }

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -91,6 +91,8 @@ void UDP::length(uint16_t new_len) {
 
 void UDP::use_checksum(bool new_use_checksum) {
     use_checksum_ = new_use_checksum;
+    if (!new_use_checksum)
+        header_.check = 0;
 }
 
 uint32_t UDP::header_size() const {

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -54,6 +54,7 @@ UDP::UDP(uint16_t dport, uint16_t sport)
 : header_() {
     this->dport(dport);
     this->sport(sport);
+    this->use_checksum(true);
 }
 
 UDP::UDP(const uint8_t* buffer, uint32_t total_sz)  {
@@ -73,6 +74,7 @@ UDP::UDP(const uint8_t* buffer, uint32_t total_sz)  {
 
         inner_pdu(new_pdu);
     }
+    this->use_checksum(true);
 }
 
 void UDP::dport(uint16_t new_dport) {
@@ -85,6 +87,10 @@ void UDP::sport(uint16_t new_sport) {
 
 void UDP::length(uint16_t new_len) {
     header_.len = Endian::host_to_be(new_len);
+}
+
+void UDP::use_checksum(bool new_use_checksum) {
+    use_checksum_ = new_use_checksum;
 }
 
 uint32_t UDP::header_size() const {
@@ -171,9 +177,15 @@ void UDP::write_serialization(uint8_t* buffer, uint32_t total_sz) {
     while (checksum >> 16) {
         checksum = (checksum & 0xffff)+(checksum >> 16);
     }
-    header_.check = ~checksum;
-    // If checksum is 0, it has to be set to 0xffff
-    header_.check = (header_.check == 0) ? 0xffff : header_.check;
+    if (use_checksum_) {
+        header_.check = ~checksum;
+        // If checksum is 0, it has to be set to 0xffff
+        header_.check = (header_.check == 0) ? 0xffff : header_.check;
+    }
+    else {
+        //Unused checksum transmitted as 0
+        header_.check = 0;
+    }
     ((udp_header*)buffer)->check = header_.check;
 }
 

--- a/tests/src/udp_test.cpp
+++ b/tests/src/udp_test.cpp
@@ -133,14 +133,17 @@ TEST_F(UDPTest, ChecksumCheck3) {
     EXPECT_EQ(0xffff, pkt.rfind_pdu<UDP>().checksum());
 }
 
-// UDP checksum is 0 for RoCE v2
+// UDP checksum is 0 for RoCE v2, test overwriting it
 TEST_F(UDPTest, ChecksumCheckRoCE) {
     EthernetII pkt(rocev2_packet, sizeof(rocev2_packet));
     UDP& udp = pkt.rfind_pdu<UDP>();
-    udp.use_checksum(false);
+
+    EXPECT_EQ(0x0, pkt.rfind_pdu<UDP>().checksum());
+    udp.checksum(0x1234);
+    EXPECT_EQ(0x1234, pkt.rfind_pdu<UDP>().checksum());
 
     PDU::serialization_type buffer = pkt.serialize();
-    EXPECT_EQ(
+    EXPECT_NE(
         UDP::serialization_type(
             rocev2_packet, 
             rocev2_packet + sizeof(rocev2_packet)
@@ -148,7 +151,7 @@ TEST_F(UDPTest, ChecksumCheckRoCE) {
         buffer
     );
 
-    EXPECT_EQ(0x0, udp.checksum());
+    EXPECT_EQ(0x1234, udp.checksum());
 }
 
 TEST_F(UDPTest, CopyConstructor) {


### PR DESCRIPTION
This change adds support in libtins for setting the IP and UDP checksums, and once doing so, disabling re-calculation of the checksum on serialization.  This allows protocols such as RoCE v2 to set the UDP checksum to 0 as described in the spec, it also allows for calculation of icrc which requires both IP and UDP checksum to be all 1s.